### PR TITLE
Add packages: write permission to pack workflow

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   pack:
     runs-on: ubuntu-latest
-    
+    permissions:
+      packages: write
+
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
The Push to GitHub Packages step was failing with an authentication error
because the GITHUB_TOKEN lacked write access to packages. Adding the
explicit packages: write permission to the job fixes this.

Fixes #16